### PR TITLE
Remove vulnerable UUID runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "react-scannable",
       "version": "0.0.18",
       "license": "MIT",
-      "dependencies": {
-        "uuid": "^9.0.0"
-      },
       "devDependencies": {
         "@types/jest": "^23.3.14",
         "@types/react": "^18.0.27",
@@ -21417,16 +21414,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
       "git add"
     ]
   },
-  "dependencies": {
-    "uuid": "^9.0.0"
-  },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/src/components/Scannable/Scannable.js
+++ b/src/components/Scannable/Scannable.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { v4 as uuidv4 } from 'uuid';
 import ScannerContext from '../Scanner/Scanner.context';
 import checkVisibleAndScroll from '../../utils/checkVisibleAndScroll';
+import uuidv4 from '../../utils/uuidv4';
 
 class Scannable extends React.Component {
   constructor(props) {

--- a/src/utils/uuidv4.js
+++ b/src/utils/uuidv4.js
@@ -1,0 +1,40 @@
+const byteToHex = Array.from({ length: 256 }, (_, index) => (index + 0x100).toString(16).slice(1));
+const randomBytes = new Uint8Array(16);
+
+export default function uuidv4(cryptoApi = typeof crypto === 'undefined' ? undefined : crypto) {
+  if (cryptoApi && cryptoApi.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+
+  if (!cryptoApi || !cryptoApi.getRandomValues) {
+    throw new Error('crypto.getRandomValues() not supported');
+  }
+
+  const bytes = cryptoApi.getRandomValues(randomBytes);
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  return (
+    byteToHex[bytes[0]] +
+    byteToHex[bytes[1]] +
+    byteToHex[bytes[2]] +
+    byteToHex[bytes[3]] +
+    '-' +
+    byteToHex[bytes[4]] +
+    byteToHex[bytes[5]] +
+    '-' +
+    byteToHex[bytes[6]] +
+    byteToHex[bytes[7]] +
+    '-' +
+    byteToHex[bytes[8]] +
+    byteToHex[bytes[9]] +
+    '-' +
+    byteToHex[bytes[10]] +
+    byteToHex[bytes[11]] +
+    byteToHex[bytes[12]] +
+    byteToHex[bytes[13]] +
+    byteToHex[bytes[14]] +
+    byteToHex[bytes[15]]
+  );
+}

--- a/src/utils/uuidv4.test.js
+++ b/src/utils/uuidv4.test.js
@@ -1,0 +1,53 @@
+import uuidv4 from './uuidv4';
+
+describe('uuidv4', () => {
+  const originalCrypto = global.crypto;
+  let sequence;
+  let cryptoApi;
+
+  beforeEach(() => {
+    sequence = 0;
+    cryptoApi = {
+      getRandomValues: (bytes) => {
+        bytes.fill(sequence++);
+        return bytes;
+      },
+    };
+  });
+
+  afterEach(() => {
+    global.crypto = originalCrypto;
+  });
+
+  it('uses the global Web Crypto API by default', () => {
+    global.crypto = cryptoApi;
+
+    expect(uuidv4()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+  });
+
+  it('generates an RFC 9562 version 4 UUID', () => {
+    expect(uuidv4(cryptoApi)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+  });
+
+  it('generates unique values', () => {
+    expect(uuidv4(cryptoApi)).not.toBe(uuidv4(cryptoApi));
+  });
+
+  it('uses native randomUUID when available', () => {
+    const expected = '00000000-0000-4000-8000-000000000000';
+    cryptoApi.randomUUID = jest.fn(() => expected);
+    cryptoApi.getRandomValues = jest.fn();
+
+    expect(uuidv4(cryptoApi)).toBe(expected);
+    expect(cryptoApi.randomUUID).toHaveBeenCalledTimes(1);
+    expect(cryptoApi.getRandomValues).not.toHaveBeenCalled();
+  });
+
+  it('requires Web Crypto', () => {
+    expect(() => uuidv4(null)).toThrow('crypto.getRandomValues() not supported');
+  });
+});


### PR DESCRIPTION
## Summary

- replace the single internal `uuid.v4()` call with a small Web Crypto-based UUID v4 helper
- remove the direct `uuid@9.0.0` runtime dependency
- add focused tests for canonical UUID format, version/variant bits, uniqueness, native `randomUUID()`, the `getRandomValues()` fallback, and missing Web Crypto
- remove the sole production audit finding

## Why not upgrade directly to UUID 14?

UUID 14 is ESM-only, exports only modern package entry points, and ships modern syntax such as optional chaining and nullish coalescing. This project's Jest 20, webpack 3, Rollup 0.64, and 2018 resolver plugins cannot consume it:

- Jest 20: `Cannot find module 'uuid'`
- webpack 3: cannot resolve the exports-only package; a deep import then fails to parse modern syntax
- Rollup 0.64: leaves the package unresolved; a deep import then fails to parse modern syntax

UUID 11.1.1 retains legacy entry points but still ships syntax these bundlers cannot parse. Supporting UUID 14 directly would therefore require a broad build-system migration.

## Behavior and compatibility

The helper was compared line by line with UUID 9's browser `v4`, RNG, native UUID, and stringify implementations. For the zero-argument call used by this project, it preserves the relevant behavior:

1. use native `crypto.randomUUID()` when available
2. otherwise fill 16 bytes using `crypto.getRandomValues()`
3. set the RFC version 4 and variant bits
4. return a lowercase canonical UUID string

Browsers already needed Web Crypto under UUID 9. Node-side execution now relies on global Web Crypto, consistent with UUID 14's Node 20+ requirement, instead of UUID 9's Node-specific crypto fallback.

## Validation

- clean `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test -- --runInBand` — 3 suites, 7 tests passed
- `npm run build`
- `NODE_OPTIONS=--openssl-legacy-provider npm run styleguide:build`
- Prettier check
- `npm audit --omit=dev` — 0 vulnerabilities

The existing Rollup circular-dependency warning and Node 22 OpenSSL compatibility flag for the legacy styleguide toolchain remain unchanged.